### PR TITLE
Configure cloudwatch log streams and SNS topic

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,17 @@
-# 🚀 Assignment-04
+# 🚀 Assignment-05
 
-This repository contains Terraform code to launch an AWS EC2 instance for different stages and create an s3 bucket to store logs for different stages. You can use this repo as
+This repository contains Terraform code
+- To launch an AWS EC2 instance for different stages
+- To create an s3 bucket to store logs for different stages and
+- To streams logs to cloudwatch
+- Created the SNS topic and configure the alarm so that it can publish the SNS Message.
+To trigger the cloudwatch alarm for SNS message:
+    - Put your email at alert_email variable in  ./terraform/variables.tf file.
+    - SSH into EC2 and simulate a log entry with suitable permissions:
+      - echo "ERROR: Simulated failure" >> /home/ec2-user/techeazy-devops/application.log
+    - You will get SNS message at your email.
+
+You can use this repo as
 
 - ✅ **Locally** on your machine
 - ✅ **Automatically** through a **GitHub Actions** workflow

--- a/scripts/cloudwatch-agent-config.json
+++ b/scripts/cloudwatch-agent-config.json
@@ -1,0 +1,22 @@
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/cloud-init-output.log",
+            "log_group_name": "${LOG_GROUP_NAME}",
+            "log_stream_name": "cloud-init-output.log",
+            "timestamp_format": "%d-%m-%Y %H:%M:%S"
+          },
+          {
+            "file_path": "/home/ec2-user/techeazy-devops/application.log",
+            "log_group_name": "${LOG_GROUP_NAME}",
+            "log_stream_name": "application.log",
+            "timestamp_format": "%d-%m-%Y %H:%M:%S"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/dev_script.sh
+++ b/scripts/dev_script.sh
@@ -50,7 +50,7 @@ sudo yum install git -y
 echo "git client installed succefully."
 echo "Cloning git repo techeazy-devops."
 
-git clone https://github.com/techeazy-consulting/techeazy-devops
+git clone https://github.com/rajgupta2/techeazy-devops
 
 cd techeazy-devops
 git checkout 4a53f230c2cf21dc641a299e3b7d326b8a9c3fa2

--- a/scripts/dev_script.sh
+++ b/scripts/dev_script.sh
@@ -1,5 +1,18 @@
 #! /bin/bash
 
+sudo yum update -y
+yum install -y amazon-cloudwatch-agent
+
+# Writing the Cloudwatch configuration
+cat <<EOF > /opt/aws/amazon-cloudwatch-agent/bin/cwagent-config.json
+${cloudwatch_agent_config}
+EOF
+
+# Start the CloudWatch Agent with the config
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+-a fetch-config -m ec2 \
+-c file:/opt/aws/amazon-cloudwatch-agent/bin/cwagent-config.json -s
+
 STOP_INSTANCE="${STOP_INSTANCE}"
 S3_BUCKET_NAME="${S3_BUCKET_NAME}"
 

--- a/scripts/prod_script.sh
+++ b/scripts/prod_script.sh
@@ -2,6 +2,19 @@
 
 set -e  # Exit on error
 
+sudo yum update -y
+yum install -y amazon-cloudwatch-agent
+
+# Writing the Cloudwatch configuration
+cat <<EOF > /opt/aws/amazon-cloudwatch-agent/bin/cwagent-config.json
+${cloudwatch_agent_config}
+EOF
+
+# Start the CloudWatch Agent with the config
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+-a fetch-config -m ec2 \
+-c file:/opt/aws/amazon-cloudwatch-agent/bin/cwagent-config.json -s
+
 STOP_INSTANCE="${STOP_INSTANCE}"
 S3_BUCKET_NAME="${S3_BUCKET_NAME}"
 GITHUB_TOKEN="${GITHUB_TOKEN}"

--- a/scripts/prod_script.sh
+++ b/scripts/prod_script.sh
@@ -53,7 +53,7 @@ sudo yum install git -y
 echo "git client installed succefully."
 echo "Cloning git repo techeazy-devops."
 
-git clone https://github.com/techeazy-consulting/techeazy-devops
+git clone https://github.com/rajgupta2/techeazy-devops
 
 cd techeazy-devops
 git checkout 4a53f230c2cf21dc641a299e3b7d326b8a9c3fa2

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,7 @@ resource "aws_instance" "webserver-techeazy" {
     STOP_INSTANCE       = var.stop_after_minutes # Match STOP_INSTANCE in script
     S3_BUCKET_NAME      = data.terraform_remote_state.shared_role.outputs.s3_log_bucket
     GITHUB_TOKEN        = nonsensitive(var.github_token)
+    cloudwatch_agent_config = data.template_file.cw_agent_config.rendered
   }))
   tags = {
     Name = "${var.instance_name}-${var.stage}"
@@ -35,5 +36,57 @@ data "terraform_remote_state" "shared_role" {
     bucket = "rajguptackt22-terraform-state"
     key    = "shared/terraform.tfstate"
     region = "ap-south-1"
+  }
+}
+
+resource "aws_sns_topic" "alarm_topic" {
+  name = "cloudwatch-log-error-topic-${var.stage}"
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.alarm_topic.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+resource "aws_cloudwatch_log_group" "cloudwatch-log-group" {
+  name = "${var.instance_name}-logs-${var.stage}"
+
+  tags = {
+    Environment = var.stage
+    Application = var.instance_name
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "error_filter" {
+  name           = "error-exception-filter"
+  log_group_name =  aws_cloudwatch_log_group.cloudwatch-log-group.name
+  pattern        = "?ERROR ?Exception"
+
+  metric_transformation {
+    name      = "ErrorCount"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+  depends_on = [aws_cloudwatch_log_group.cloudwatch-log-group]
+}
+
+resource "aws_cloudwatch_metric_alarm" "log_error_alarm" {
+  alarm_name          = "LogErrorOrExceptionAlarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.error_filter.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.error_filter.metric_transformation[0].namespace
+  period              = 300 # 5 minutes
+  statistic           = "Sum"
+  threshold           = 2  # More than 1 datapoint means 2 or more
+  alarm_description   = "Triggers when ERROR or Exception is found more than once in 5 minutes"
+  alarm_actions       = [aws_sns_topic.alarm_topic.arn]
+}
+
+data "template_file" "cw_agent_config" {
+  template = file("${path.module}/../scripts/cloudwatch-agent-config.json")
+  vars = {
+    LOG_GROUP_NAME = aws_cloudwatch_log_group.cloudwatch-log-group.name
   }
 }

--- a/terraform/shared/output.tf
+++ b/terraform/shared/output.tf
@@ -1,5 +1,5 @@
 output "ec2-instance-profile" {
-  description = "This is instance profile that we need to attach to 'EC2 having Hosting App'."
+  description = "This instance profile have S3-write-access and it can upload log stream to cloudwatch."
   value = aws_iam_instance_profile.ec2-instance-profile.name
 }
 output "s3_log_bucket" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,3 +49,9 @@ variable "github_token" {
   type        = string
   sensitive   = true
 }
+
+variable "alert_email" {
+  description = "Email address to receive SNS alerts"
+  type        = string
+  default     = "rajgupta.ckt.swe@gmail.com"
+}


### PR DESCRIPTION
# Streams logs to cloudwatch and created the SNS topic and configure the alarm so that it can publish the SNS Message.
- To trigger the cloudwatch alarm for SNS message:
    - Put your email at **alert_email variable in  ./terraform/variables.tf file.**
    - SSH into EC2 and simulate a log entry **with suitable permissions:**
      - echo "ERROR: Simulated failure" >> /home/ec2-user/techeazy-devops/application.log
    - You will get SNS message at your email.